### PR TITLE
Issue 80 - Fix up static file serving

### DIFF
--- a/server/api/settings.py
+++ b/server/api/settings.py
@@ -165,7 +165,7 @@ STATIC_ROOT = os.path.join(PROJECT_ROOT, "static_files")
 
 # This is where to _find_ static files when 'collectstatic' is run.
 # These files are then copied to the STATIC_ROOT location.
-STATICFILES_DIRS = (os.path.join(PROJECT_ROOT, "static"),)
+STATICFILES_DIRS = (os.path.join(PROJECT_ROOT, "app", "static"),)
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field


### PR DESCRIPTION
## Change Summary
Now finds the files that were uploaded and copies them to the STATIC_ROOT. Kinda got confused because the docker names are different to the local names but it worked out in the end. Now that error of "The directory '/static' in the STATICFILES_DIRS setting does not exist." is gone too!

Frontend should now be able to grab images from that link and use them accordingly for the events!

### Change Form
- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation



# Related issue

- Resolve #80