### PR TITLE
Issue 99 fix further issues with rsvp endpoint

### DIFF
--- a/server/api/event/urls.py
+++ b/server/api/event/urls.py
@@ -7,7 +7,7 @@ router.register(r"", views.EventViewSet, basename="event")
 
 urlpatterns = [
     path("", include(router.urls)),
-    path("<int:event_id>/rsvp/", views.rsvp_list_create, name="rsvp-list-create"),
+    path("<int:event_id>/rsvp/", views.rsvp_event_view, name="rsvp-event-view"),
     path("<int:event_id>/rsvp/<int:id>/", views.rsvp_detail, name="rsvp-detail"),
     path("<int:event_id>/has_rsvp", views.has_rsvp, name="has-rsvp"),
 ]

--- a/server/api/event/urls.py
+++ b/server/api/event/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     path("", include(router.urls)),
     path("<int:event_id>/rsvp/", views.rsvp_event_view, name="rsvp-event-view"),
     path("<int:event_id>/rsvp/<int:id>/", views.rsvp_detail, name="rsvp-detail"),
-    path("<int:event_id>/has_rsvp", views.has_rsvp, name="has-rsvp"),
+    path("<int:event_id>/has_rsvp/", views.has_rsvp, name="has-rsvp"),
 ]

--- a/server/api/event/urls.py
+++ b/server/api/event/urls.py
@@ -6,9 +6,8 @@ router = DefaultRouter()
 router.register(r"", views.EventViewSet, basename="event")
 
 urlpatterns = [
-    path('', include(router.urls)),
-    path('<int:event_id>/rsvp/', views.rsvp_list_create,
-         name='rsvp-list-create'),
-    path('<int:event_id>/rsvp/<int:id>/', views.rsvp_detail,
-         name='rsvp-detail'),
+    path("", include(router.urls)),
+    path("<int:event_id>/rsvp/", views.rsvp_list_create, name="rsvp-list-create"),
+    path("<int:event_id>/rsvp/<int:id>/", views.rsvp_detail, name="rsvp-detail"),
+    path("<int:event_id>/has_rsvp", views.has_rsvp, name="has-rsvp"),
 ]

--- a/server/api/event/views.py
+++ b/server/api/event/views.py
@@ -42,7 +42,7 @@ class EventViewSet(viewsets.ModelViewSet):
 
 @api_view(["GET", "POST"])
 @permission_classes([IsAuthenticated])
-def rsvp_list_create(request: HttpRequest, event_id):
+def rsvp_event_view(request: HttpRequest, event_id):
     if request.method == "GET":
         rsvps = RSVP.objects.filter(event__id=event_id)
         serializer = RSVPSerializer(rsvps, many=True)

--- a/server/api/event/views.py
+++ b/server/api/event/views.py
@@ -40,7 +40,7 @@ class EventViewSet(viewsets.ModelViewSet):
     permission_classes = [isStaffOrReadonly]
 
 
-@api_view(["GET", "POST"])
+@api_view(["GET", "POST", "DELETE"])
 @permission_classes([IsAuthenticated])
 def rsvp_event_view(request: HttpRequest, event_id):
     if request.method == "GET":
@@ -61,6 +61,15 @@ def rsvp_event_view(request: HttpRequest, event_id):
         response_data = {}
         response_data["rsvp_id"] = rsvp.id
         return Response(response_data, status=status.HTTP_201_CREATED)
+
+    elif request.method == "DELETE":
+        try:
+            rsvp = RSVP.objects.get(event_id=event_id, user=request.user)
+        except ObjectDoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        rsvp.delete()
+        return Response(status=status.HTTP_200_OK)
 
 
 @api_view(["GET", "PATCH", "DELETE"])


### PR DESCRIPTION
## Change Summary
- Fix endpoint for creating RSVP for a given event.
- Add a DELETE endpoint that allows deleting the users RSVP for a given event.
- Rename event RSVP view function.

## Other Information
*Potentially more work to done on this in the future, however just need this to work for now so I can finish with connecting event page to backend.*
- Might make more sense to persist an RSVP instance but add an 'active' flag to the model. That way the system won't cycle through ID's if a user RSVP's and unRSVP's to an event multiple times.
- Could simplify things if we just added an endpoint to toggle the status of the users RSVP to an event.
- I'm not sure if we are even using the rsvp_detail endpoint so this could potentially be removed.

# Related issue

- Resolve #99