### PR TITLE
Issue 68 connect single event page to backend

### DIFF
--- a/client/src/components/main/EventPage.tsx
+++ b/client/src/components/main/EventPage.tsx
@@ -1,5 +1,5 @@
 import { format as dateFormat } from "date-fns";
-import { Edit, Mail } from "lucide-react";
+import { Edit, Mail, X } from "lucide-react";
 import Image from "next/image";
 
 import { type Event } from "@/hooks/useEvent";
@@ -35,7 +35,9 @@ export const EventPage = ({
   const { mutate: deleteRsvp } = useDeleteRsvp(id);
 
   const attendeeControls = () => {
-    if (rsvp_query.data) {
+    if (status != "Upcoming") {
+      return <></>;
+    } else if (rsvp_query.data) {
       return (
         <button
           className="flex items-center justify-between gap-2 rounded-xl border border-black px-3 py-1 hover:bg-[#9DAD93]"
@@ -43,7 +45,7 @@ export const EventPage = ({
             deleteRsvp();
           }}
         >
-          Remove RSVP <Mail strokeWidth="1" size="20" />
+          Remove RSVP <X strokeWidth="1" size="20" />
         </button>
       );
     } else {
@@ -89,6 +91,22 @@ export const EventPage = ({
     }
   };
 
+  const renderImage = () => {
+    if (image != null) {
+      return (
+        <Image
+          fill
+          unoptimized={true}
+          src={image}
+          alt="Event image"
+          className="rounded object-cover"
+        />
+      );
+    } else {
+      return <span className="italic">No image provided for this event</span>;
+    }
+  };
+
   return (
     <div className="m-3 h-full rounded-[40px] bg-[#9DAD93] p-3 md:p-6 lg:mx-16">
       <div className="flex h-full flex-col items-center rounded-[32px] bg-white px-8 py-4">
@@ -102,14 +120,8 @@ export const EventPage = ({
 
         <div className="my-5 grid h-full w-full grid-rows-[1fr,1px,1fr] md:grid-cols-[1fr,1px,1fr] md:grid-rows-[400px]">
           <div className="mb-5 flex flex-col items-center justify-center md:mb-0 md:mr-10 md:items-end">
-            <div className="relative h-full max-h-[300px] w-full max-w-[500px]">
-              <Image
-                fill
-                unoptimized={true}
-                src={image}
-                alt="Event image"
-                className="rounded object-cover"
-              />
+            <div className="relative flex h-full max-h-[300px] w-full max-w-[500px] items-center justify-center">
+              {renderImage()}
             </div>
           </div>
           <div className="border-t border-black md:border-l"></div>

--- a/client/src/components/main/EventPage.tsx
+++ b/client/src/components/main/EventPage.tsx
@@ -1,31 +1,12 @@
-import { useMutation } from "@tanstack/react-query";
 import { format as dateFormat } from "date-fns";
 import { Edit, Mail } from "lucide-react";
 import Image from "next/image";
 
-import { type Event, useGetUserHasRsvp } from "@/hooks/getEvent";
+import { type Event } from "@/hooks/useEvent";
+import { useAddRsvp, useDeleteRsvp, useHasRsvp } from "@/hooks/useRsvp";
 import useUser from "@/hooks/useUser";
-import api from "@/lib/api";
 
 import RsvpListModal from "./RsvpListModal";
-
-const useAddRsvp = (event_id: number) => {
-  return useMutation({
-    mutationKey: ["rsvp_add", event_id],
-    mutationFn: () => {
-      return api.post(`/event/${event_id}/rsvp/`);
-    },
-  });
-};
-
-const useDeleteRsvp = (event_id: number) => {
-  return useMutation({
-    mutationKey: ["rsvp_delete", event_id],
-    mutationFn: () => {
-      return api.delete(`/event/${event_id}/rsvp/`);
-    },
-  });
-};
 
 type EventPageProps = {
   event: Event;
@@ -49,12 +30,12 @@ export const EventPage = ({
   const end_fmt = dateFormat(end_time, "hh:mm aa");
 
   const user_query = useUser();
-  const rsvp_query = useGetUserHasRsvp(id);
+  const rsvp_query = useHasRsvp(id);
   const { mutate: addRsvp } = useAddRsvp(id);
   const { mutate: deleteRsvp } = useDeleteRsvp(id);
 
   const attendeeControls = () => {
-    if (rsvp_query.data?.has_rsvp) {
+    if (rsvp_query.data) {
       return (
         <button
           className="flex items-center justify-between gap-2 rounded-xl border border-black px-3 py-1 hover:bg-[#9DAD93]"
@@ -81,6 +62,7 @@ export const EventPage = ({
 
   const posterControls = (
     <div className="mt-2 flex gap-2">
+      TODO: Needs to be connected to Edit Event modal
       <button className="flex items-center justify-between gap-2 rounded-xl border border-black px-3 py-1 hover:bg-[#9DAD93]">
         Edit <Edit strokeWidth="1" size="20" />
       </button>

--- a/client/src/components/main/EventPage.tsx
+++ b/client/src/components/main/EventPage.tsx
@@ -64,7 +64,7 @@ export const EventPage = ({
 
   const posterControls = (
     <div className="mt-2 flex gap-2">
-      TODO: Needs to be connected to Edit Event modal
+      {/* TODO: Needs to be connected to Edit Event modal */}
       <button className="flex items-center justify-between gap-2 rounded-xl border border-black px-3 py-1 hover:bg-[#9DAD93]">
         Edit <Edit strokeWidth="1" size="20" />
       </button>

--- a/client/src/hooks/useEvent.ts
+++ b/client/src/hooks/useEvent.ts
@@ -1,5 +1,4 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
-import { AxiosError } from "axios";
 
 import api from "@/lib/api";
 
@@ -26,15 +25,6 @@ export type Event = {
   status: EventStatus;
 };
 
-export type RsvpInfo =
-  | {
-      has_rsvp: boolean;
-      rsvp_id: number;
-    }
-  | {
-      has_rsvp: false;
-    };
-
 export const useGetEvent = (
   eventId: number,
   args?: Omit<UseQueryOptions<Event, Error>, "queryKey" | "queryFn">,
@@ -44,17 +34,5 @@ export const useGetEvent = (
     queryKey: ["event", eventId],
     queryFn: async () => api.get(`/event/${eventId}/`).then((res) => res.data),
     enabled: eventId !== undefined,
-  });
-};
-
-export const useGetUserHasRsvp = (
-  eventId: number,
-  args?: Omit<UseQueryOptions<RsvpInfo, AxiosError>, "queryKey" | "queryFn">,
-) => {
-  return useQuery<RsvpInfo, AxiosError>({
-    ...args,
-    queryKey: ["event_has_rsvp", eventId],
-    queryFn: async () =>
-      api.get(`/event/${eventId}/has_rsvp`).then((res) => res.data.has_rsvp),
   });
 };

--- a/client/src/hooks/useRsvp.ts
+++ b/client/src/hooks/useRsvp.ts
@@ -28,7 +28,7 @@ export const useAddRsvp = (event_id: number) => {
       return api.post(`/event/${event_id}/rsvp/`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["event_has_rsvp", event_id] });
+      queryClient.setQueryData(["event_has_rsvp", event_id], true);
     },
   });
 };
@@ -41,7 +41,7 @@ export const useDeleteRsvp = (event_id: number) => {
       return api.delete(`/event/${event_id}/rsvp/`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["event_has_rsvp", event_id] });
+      queryClient.setQueryData(["event_has_rsvp", event_id], false);
     },
   });
 };

--- a/client/src/hooks/useRsvp.ts
+++ b/client/src/hooks/useRsvp.ts
@@ -1,0 +1,47 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import api from "@/lib/api";
+
+export const useHasRsvp = (
+  eventId: number,
+  args?: Omit<UseQueryOptions<boolean, AxiosError>, "queryKey" | "queryFn">,
+) => {
+  return useQuery<boolean, AxiosError>({
+    ...args,
+    queryKey: ["event_has_rsvp", eventId],
+    queryFn: async () =>
+      api.get(`/event/${eventId}/has_rsvp/`).then((res) => res.data.has_rsvp),
+  });
+};
+
+export const useAddRsvp = (event_id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ["rsvp_add", event_id],
+    mutationFn: () => {
+      return api.post(`/event/${event_id}/rsvp/`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["event_has_rsvp", event_id] });
+    },
+  });
+};
+
+export const useDeleteRsvp = (event_id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ["rsvp_delete", event_id],
+    mutationFn: () => {
+      return api.delete(`/event/${event_id}/rsvp/`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["event_has_rsvp", event_id] });
+    },
+  });
+};

--- a/client/src/pages/event/[id].tsx
+++ b/client/src/pages/event/[id].tsx
@@ -2,7 +2,7 @@ import Error from "next/error";
 import { useRouter } from "next/router";
 
 import { EventPage } from "@/components/main/EventPage";
-import { useGetEvent } from "@/hooks/getEvent";
+import { useGetEvent } from "@/hooks/useEvent";
 
 export default function Event() {
   const router = useRouter();


### PR DESCRIPTION
## Change Summary
- Single event page now fetches data from the backend.
- Depending on the users role, different control buttons are shown.
- If the user is an attendee and the event still has the 'Upcoming' status, the user can both send and remove an RSVP to the event.
- If the user is a poster, they have a button to open the RSVP list modal, and a button to open the edit event modal (waiting on issue 93 to be completed).

# Related issue

- Resolve #68