### PR TITLE
Use version 16 for postgres database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: coexist-db
-    image: postgres
+    image: postgres:16
     restart: unless-stopped
     volumes:
       - ${LOCAL_WORKSPACE_FOLDER:-.}/data/db:/var/lib/postgresql/data


### PR DESCRIPTION
## Change Summary
The database container now explicitly uses postgres version 16.

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related issue

- Resolve #115