### PR TITLE
Fix RSVP modal table headers and added phone number

### DIFF
--- a/client/src/components/main/RsvpListModal.tsx
+++ b/client/src/components/main/RsvpListModal.tsx
@@ -71,13 +71,16 @@ export default function RsvpListModal({ eventId }: RsvpListModalProps) {
           <TableHeader>
             <TableRow>
               <TableHead className="border-b border-r border-[#7D916F] text-black">
-                Username
+                First Name
               </TableHead>
               <TableHead className="border-b border-r border-[#7D916F] text-black">
                 Last Name
               </TableHead>
               <TableHead className="border-b border-r border-[#7D916F] text-black">
                 Email
+              </TableHead>
+              <TableHead className="border-b border-[#7D916F] text-black">
+                Phone Number
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -90,8 +93,11 @@ export default function RsvpListModal({ eventId }: RsvpListModalProps) {
                 <TableCell className="border-r border-t border-r-[#7D916F] border-t-[#DEE4DB]">
                   {a.user.last_name}
                 </TableCell>
-                <TableCell className="text6789-[#5C764B] border-t border-t-[#DEE4DB] underline">
+                <TableCell className="text6789-[#5C764B] border-r border-t border-r-[#7D916F] border-t-[#DEE4DB] underline">
                   <a href={`mailto:${a.user.email}`}>{a.user.email}</a>
+                </TableCell>
+                <TableCell className="border-t border-t-[#DEE4DB]">
+                  {a.user.phone}
                 </TableCell>
               </TableRow>
             ))}

--- a/client/src/hooks/getRSVPs.ts
+++ b/client/src/hooks/getRSVPs.ts
@@ -11,6 +11,7 @@ interface User {
   first_name: string;
   last_name: string;
   email: string;
+  phone: string;
 }
 
 interface RSVP {


### PR DESCRIPTION
## Change Summary
The column labelled "Username" now correctly says "First Name". The phone number column has also been added.

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related issue

- Resolve #120