### PR TITLE
onHoverStyle no longer rounded

### DIFF
--- a/client/src/components/main/header/Navbar.tsx
+++ b/client/src/components/main/header/Navbar.tsx
@@ -8,7 +8,7 @@ import { useAuth } from "@/context/AuthProvider";
 import { DropDownNav } from "./DropDown";
 
 const onHoverStyle =
-  "rounded border-b-4 border-transparent px-2 hover:border-[#5C764B] hover:opacity-80";
+  "border-b-4 border-transparent px-2 hover:border-[#5C764B] hover:opacity-80";
 const outlineStyle =
   "rounded-lg border-2 border-white p-1 px-4 hover:opacity-70";
 


### PR DESCRIPTION
Literally just removed the 'rounded' tag on hover underline for buttons.

It looks odd as the underline curves for no visually discernible reason (since the button is transparent).

## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**